### PR TITLE
Change README to relative paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Or with the developer mode
 * Select the extension
 * Click on `Options`
 
-<img src="https://github.com/Darkempire78/Github1s-Extension/blob/main/assets/Capture3.PNG"/>
+<img src="assets/Capture3.PNG"/>
 
 ## Contributing
 
@@ -52,4 +52,4 @@ Please make sure to update tests as appropriate.
 
 ## License
 
-This project is under [GPLv3](https://github.com/Darkempire78/Github1s-Extension/blob/master/LICENSE).
+This project is under [GPLv3](LICENSE).


### PR DESCRIPTION
The License path points to the master branch while the image path points to the main branch. This already shows the issue that happens with absolute paths and also the reason why I did this change. Plus relative paths will also work in text editors, so this will be a nice little improvement in case someone opens this in Github1s!

https://github.blog/2013-01-31-relative-links-in-markup-files/